### PR TITLE
Associate with .nginx files

### DIFF
--- a/syntaxes/nginx.tmLanguage
+++ b/syntaxes/nginx.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>conf</string>
+		<string>nginx</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>\{\s*$</string>


### PR DESCRIPTION
As there are many .conf files it can be good practise to use the .nginx file extension for Nginx configurations. This  is also adopted by the "language-nginx" extension for Atom, making the behaviour consistent for developers cross multiple editors.